### PR TITLE
fix: changed name on subnet delegations service actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ module "network" {
         delegations = {
           sql = {
             name = "Microsoft.Sql/managedInstances"
-            service_actions = [
+            actions = [
               "Microsoft.Network/virtualNetworks/subnets/join/action",
               "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
               "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",

--- a/examples/delegations/main.tf
+++ b/examples/delegations/main.tf
@@ -30,7 +30,7 @@ module "network" {
         delegations = {
           sql = {
             name = "Microsoft.Sql/managedInstances"
-            service_actions = [
+            actions = [
               "Microsoft.Network/virtualNetworks/subnets/join/action",
               "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
               "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",

--- a/main.tf
+++ b/main.tf
@@ -54,7 +54,7 @@ resource "azurerm_subnet" "subnets" {
 
       service_delegation {
         name    = delegation.value.name
-        actions = try(lookup(delegation.value, "service_actions", []), [])
+        actions = try(lookup(delegation.value, "actions", []), [])
       }
     }
   }


### PR DESCRIPTION
In line with how the property is named from the official documentation:
[https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet](url)